### PR TITLE
Fix typo in AsInt

### DIFF
--- a/src/Emu/Utility/GenericOperation.h
+++ b/src/Emu/Utility/GenericOperation.h
@@ -141,7 +141,7 @@ struct AsInt : public std::unary_function<OpEmulationState*, Type>
 {
     Type operator()(OpEmulationState* opState)
     {
-        return AsFPFunc<Type>( TSrc()(opState) );
+        return AsIntFunc<Type>( TSrc()(opState) );
     }
 };
 


### PR DESCRIPTION
コメントと名付けを見る限りでは，GenericOperationのAsIntがAsFPFuncを呼んでいるのはtypoでAsIntFuncを呼ぶのが正しいように見えます．
ただAsIntFuncとAsFPFuncは外延的には等価で特に現状のままで問題はないんですが一応…