### PR TITLE
Fix recovery stall bug

### DIFF
--- a/src/Sim/Foundation/TimeWheel/ClockedResourceBase.h
+++ b/src/Sim/Foundation/TimeWheel/ClockedResourceBase.h
@@ -211,13 +211,13 @@ namespace Onikiri
         }
 
         // Cancel a stall period set by StallNextCycle.
-        virtual void CacnelStallPeriod()
+        virtual void CancelStallPeriod()
         {
             m_stallPeriod = 0;
 
             Children::iterator end = m_children.end();
             for( Children::iterator i = m_children.begin(); i != end; ++i ){
-                (*i)->CacnelStallPeriod();
+                (*i)->CancelStallPeriod();
             }
         }
 

--- a/src/Sim/Foundation/TimeWheel/ClockedResourceIF.h
+++ b/src/Sim/Foundation/TimeWheel/ClockedResourceIF.h
@@ -82,7 +82,7 @@ namespace Onikiri
         virtual void StallNextCycle( int cycle ) = 0;
 
         // Cancel a stall period set by StallNextCycle.
-        virtual void CacnelStallPeriod() = 0;
+        virtual void CancelStallPeriod() = 0;
 
         // Get a priority of this resource.
         // Priority constants are defined in "Sim/ResourcePriority.h".

--- a/src/Sim/Pipeline/PipelineNodeBase.h
+++ b/src/Sim/Pipeline/PipelineNodeBase.h
@@ -129,6 +129,7 @@ namespace Onikiri
         // overwrites this method.
         virtual void ExitUpperPipeline( OpIterator op )
         {
+            ASSERT( !IsStalledThisCycle(), "An op exits an upper pipeline, but this pipeline node cannot receive the op on account of a stall." );
             if( m_enableLatch ){
                 m_latch.Receive( op );
             }

--- a/src/Sim/Recoverer/Recoverer.cpp
+++ b/src/Sim/Recoverer/Recoverer.cpp
@@ -110,6 +110,9 @@ void Recoverer::RecoverBPredMiss( OpIterator branch )
     // Set a correct branch result.
     m_thread->SetFetchPC( branch->GetNextPC() );
 
+    // Cancel stall of a fetcher.
+    m_thread->GetCore()->GetFetcher()->CancelStallPeriod();
+
     // Stall a fetcher for a recovery latency.
     int latency = m_brPredRecoveryLatency;
     if( latency > 0 ){
@@ -134,6 +137,9 @@ void Recoverer::RecoverException( OpIterator causer )
     Exception exception = causer->GetException();
     exception.exception = false;
     causer->SetException( exception );
+
+    // Cancel stall of a fetcher.
+    m_thread->GetCore()->GetFetcher()->CancelStallPeriod();
 
     // Stall a fetcher for a recovery latency.
     int latency = m_exceptionRecoveryLatency;
@@ -269,6 +275,9 @@ int Recoverer::RecoverByRefetch( OpIterator /*missedOp*/, OpIterator startOp )
     // Flush backward ops.
     int flushedInsns = 
         m_inorderList->FlushBackward( m_inorderList->GetFrontOpOfSamePC( startOp ) );
+
+    // Cancel stall of a fetcher.
+    m_thread->GetCore()->GetFetcher()->CancelStallPeriod();
 
     // Set a correct branch result.
     m_thread->SetFetchPC( fetchPC );


### PR DESCRIPTION
リカバリ時にFetcherがストールから起き上がるのが遅い問題を直しました。
性能はほとんどのベンチマークで微増、平均0.3%向上です。
403.gcc、445.gobmk、483.xalancbmkで1%を超える性能向上が見られましたが、いずれも命令キャッシュに厳しいベンチマークとなっており、命令キャッシュミスが多く発生するため性能向上幅が大きい結果になったと納得できます。

