### PR TITLE
Fix machine type does not match error at benchmark/HelloWorld

### DIFF
--- a/benchmark/HelloWorld/param.xml
+++ b/benchmark/HelloWorld/param.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
 <Session>
 
-  <Emulator>
+  <Emulator TargetArchitecture="AlphaLinux">
     <Processes>
 			<!--
 				TargetBasePath　：ターゲット指定の際の起点となるディレクトリのパス（必須）


### PR DESCRIPTION
This PR fixes the following error at benchmark/HelloWorld in Quickstart steps.

```
Onikiri Version 2.9000
Emulator ...

../../../src/Emu/Utility/System/Loader/Linux64Loader.cpp(118):
  Method: virtual void Onikiri::EmulatorUtility::Linux64Loader::LoadBinary(Onikiri::EmulatorUtility::MemorySystem*, const Onikiri::String&)
  Object: Unknown
  Message: XXX/benchmark/HelloWorld/a.out : machine type does not match
```
